### PR TITLE
feat: add footer

### DIFF
--- a/components/Alert.tsx
+++ b/components/Alert.tsx
@@ -1,0 +1,7 @@
+export const Alert = () => {
+    return (
+        <div className="rounded-md text-white bg-devkor h-[3.5rem] flex justify-start items-center px-5">
+            <p className="">클립보드에 복사되었습니다</p>
+        </div>
+    );
+};

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -4,46 +4,60 @@ import { FiMail, FiInstagram } from "react-icons/fi";
 import { SiNotion } from "react-icons/si";
 import { useRouter } from "next/router";
 import { DevKorApply } from "../constants/devkor";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { Alert } from "./Alert";
 
 export const Footer = () => {
     const router = useRouter();
     const [copied, setCopied] = useState<boolean>(false);
+
+    useEffect(() => {
+        setInterval(() => {
+            setCopied(false);
+        }, 4000);
+    }, [copied]);
+
     return (
-        <div className="border-t border-devkor text-devkor px-[9.375rem] pb-5">
-            <div>
-                <Image src="/images/devkor-logo.svg" alt="devkor-logo" width="100" height="100" />
+        <div className="border-t border-devkor text-devkor px-[9.375rem] pb-5 flex relative">
+            <div className="w-[70%]">
+                <div>
+                    <Image src="/images/devkor-logo.svg" alt="devkor-logo" width="100" height="100" />
+                </div>
+                <h4>문의</h4>
+                <div className="flex pt-5">
+                    <RiKakaoTalkFill
+                        className="mr-[0.6rem] text-2xl cursor-pointer"
+                        onClick={() => {
+                            router.push(DevKorApply.kakao);
+                        }}
+                    />
+                    <FiMail
+                        className="mx-[0.6rem] text-2xl cursor-pointer"
+                        onClick={() => {
+                            navigator.clipboard.writeText(DevKorApply.email);
+                            setCopied(true);
+                        }}
+                    />
+                    <SiNotion
+                        className="mx-[0.6rem] text-2xl cursor-pointer"
+                        onClick={() => {
+                            router.push(DevKorApply.notion);
+                        }}
+                    />
+                    <FiInstagram
+                        className="ml-[0.6rem] text-2xl cursor-pointer"
+                        onClick={() => {
+                            router.push(DevKorApply.instagram);
+                        }}
+                    />
+                </div>
+                <div className="border-b border-devkor mt-5 w-[30%]"></div>
+                <p className="text-sm font-light mt-3">Copyright ⓒ DevKor. All Rights Reserved.</p>
             </div>
-            <h4>문의</h4>
-            <div className="flex pt-5">
-                <RiKakaoTalkFill
-                    className="mr-[0.6rem] text-2xl cursor-pointer"
-                    onClick={() => {
-                        router.push(DevKorApply.kakao);
-                    }}
-                />
-                <FiMail
-                    className="mx-[0.6rem] text-2xl cursor-pointer"
-                    onClick={() => {
-                        navigator.clipboard.writeText(DevKorApply.email);
-                        setCopied(true);
-                    }}
-                />
-                <SiNotion
-                    className="mx-[0.6rem] text-2xl cursor-pointer"
-                    onClick={() => {
-                        router.push(DevKorApply.notion);
-                    }}
-                />
-                <FiInstagram
-                    className="ml-[0.6rem] text-2xl cursor-pointer"
-                    onClick={() => {
-                        router.push(DevKorApply.instagram);
-                    }}
-                />
+
+            <div className={"w-[20%] absolute bottom-5 right-3 transition-all duration-500 " + (copied ? "opacity-100" : "opacity-0")}>
+                <Alert />
             </div>
-            <div className="border-b border-devkor mt-5 w-[30%]"></div>
-            <p className="text-sm font-light mt-3">Copyright ⓒ DevKor. All Rights Reserved.</p>
         </div>
     );
 };

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,49 @@
+import Image from "next/image";
+import { RiKakaoTalkFill } from "react-icons/ri";
+import { FiMail, FiInstagram } from "react-icons/fi";
+import { SiNotion } from "react-icons/si";
+import { useRouter } from "next/router";
+import { DevKorApply } from "../constants/devkor";
+import { useState } from "react";
+
+export const Footer = () => {
+    const router = useRouter();
+    const [copied, setCopied] = useState<boolean>(false);
+    return (
+        <div className="border-t border-devkor text-devkor px-[9.375rem] pb-5">
+            <div>
+                <Image src="/images/devkor-logo.svg" alt="devkor-logo" width="100" height="100" />
+            </div>
+            <h4>문의</h4>
+            <div className="flex pt-5">
+                <RiKakaoTalkFill
+                    className="mr-[0.6rem] text-2xl cursor-pointer"
+                    onClick={() => {
+                        router.push(DevKorApply.kakao);
+                    }}
+                />
+                <FiMail
+                    className="mx-[0.6rem] text-2xl cursor-pointer"
+                    onClick={() => {
+                        navigator.clipboard.writeText(DevKorApply.email);
+                        setCopied(true);
+                    }}
+                />
+                <SiNotion
+                    className="mx-[0.6rem] text-2xl cursor-pointer"
+                    onClick={() => {
+                        router.push(DevKorApply.notion);
+                    }}
+                />
+                <FiInstagram
+                    className="ml-[0.6rem] text-2xl cursor-pointer"
+                    onClick={() => {
+                        router.push(DevKorApply.instagram);
+                    }}
+                />
+            </div>
+            <div className="border-b border-devkor mt-5 w-[30%]"></div>
+            <p className="text-sm font-light mt-3">Copyright ⓒ DevKor. All Rights Reserved.</p>
+        </div>
+    );
+};

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import Header from "./Header";
+import { Footer } from "./Footer";
 
 export const Layout = ({ children }: { children: React.ReactNode }) => {
     return (
         <div className="bg-black w-full">
             <Header />
             <main className="px-[9.375rem]">{children}</main>
+            <Footer />
         </div>
     );
 };

--- a/constants/devkor.ts
+++ b/constants/devkor.ts
@@ -1,0 +1,6 @@
+export const DevKorApply = {
+    kakao: "https://open.kakao.com/o/skPP5mNe",
+    email: "devkor.apply@gmail.com",
+    notion: "https://devkor.notion.site/DevKor-670168c4662a4582b447cfba6f7206f4",
+    instagram: "https://www.instagram.com/devkor.ku",
+};


### PR DESCRIPTION
- Footer 추가
- Footer에 있는 카카오/노션 등 아이콘 라우팅
- develop 에서 브랜치를 분기했어야 하는데 Feature/mypage에서 분기를 해서,, 지금 develop으로 바로 머지하는 것보다는 Feature/mypage로 머지한 후, myPage 작업 끝난 후 develop으로 일괄 머지하는게 나을 것 같습니다. (어차피 Footer 지금 당장 쓸 일 없으니) => commit diff 만 확인해주세요! (diff부분이 지금 딱 Footer 작업 사항들!)

[TODO 겸 논의사항]
- email의 경우, 클립보드 복사로 작업했는데, "클립보드에 복사되었습니다" 를 알림으로 띄워주어야 함 (어디다 어떻게 띄울지!)
